### PR TITLE
Can now invite somebody with a github username w/ sad paths

### DIFF
--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -1,0 +1,36 @@
+class InviteController < ApplicationController
+  def new; end
+
+  def create
+    results = GithubResults.new(current_user)
+    email = results.user_email(params[:github_username])
+    if email == 'Not Found'
+      no_github_username
+    elsif email.nil?
+      github_no_email
+    else
+      github_email(email)
+    end
+  end
+
+  private
+
+  def no_github_username
+    flash[:error] = 'There is no Github user with that username.'
+    render :new
+  end
+
+  def github_no_email
+    flash[:notice] = "The Github user you selected doesn't have an email
+                      address associated with their account."
+    redirect_to dashboard_path
+  end
+
+  def github_email(email)
+    flash[:success] = 'Successfully sent invite!'
+    InvitationMailer.invite(params[:github_username],
+                            current_user.github_username,
+                            email).deliver_now
+    redirect_to dashboard_path
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'secure-fjord@brownfield.com'
+  default from: 'brownfield@secure-fjord.com'
   layout 'mailer'
   default_url_options[:host] = 'https://secure-fjord-62840.herokuapp.com/'
 end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -1,0 +1,7 @@
+class InvitationMailer < ApplicationMailer
+  def invite(invited, inviter, recipient)
+    @invited = invited
+    @inviter = inviter
+    mail(to: recipient, subject: "You've been invited to join!")
+  end
+end

--- a/app/poros/github_results.rb
+++ b/app/poros/github_results.rb
@@ -23,4 +23,13 @@ class GithubResults
       Following.new(resp)
     end
   end
+
+  def user_email(username)
+    email_results = @github_service.user_resp(username)
+    if !email_results[:message].nil?
+      email_results[:message]
+    else
+      email_results[:email]
+    end
+  end
 end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -23,4 +23,9 @@ class GithubService
     following_resp = conn.get('/user/following')
     JSON.parse(following_resp.body, symbolize_names: true)
   end
+
+  def user_resp(username)
+    user_resp = conn.get("users/#{username}")
+    JSON.parse(user_resp.body, symbolize_names: true)
+  end
 end

--- a/app/views/invitation_mailer/invite.html.erb
+++ b/app/views/invitation_mailer/invite.html.erb
@@ -1,0 +1,3 @@
+Hello <%= @invited %>,
+
+<%= @inviter %> has invited you to join Secure Fjord. You can create an account <%= link_to "here", register_url %>.

--- a/app/views/invitation_mailer/invite.text.erb
+++ b/app/views/invitation_mailer/invite.text.erb
@@ -1,0 +1,3 @@
+Hello <%= @invited %>,
+
+<%= @inviter %> has invited you to join Secure Fjord. You can create an account <%= link_to "here", register_url %>.

--- a/app/views/invite/new.html.erb
+++ b/app/views/invite/new.html.erb
@@ -1,0 +1,7 @@
+<h4>Github Invite</h4>
+
+<%= form_tag invite_path, method: :post do %>
+  <%= label_tag :github_username, "Github Invitee" %><br/>
+  <%= text_field_tag :github_username %><br/>
+  <%= submit_tag "Send Invite" %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,6 +11,7 @@
   </ul>
   <% if !@results.nil? %>
     <section class="github"><h3>Github</h3>
+      <%= button_to 'Send an Invite', invite_path, method: 'get', class: "btn btn-primary mb1 bg-teal" %>
     <% @repos.each do |resp| %>
       <%= link_to resp.name, resp.html_url %><br/>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
   root 'welcome#index'
   get 'tags/:tag', to: 'welcome#index', as: :tag
   get '/register', to: 'users#new'
+  get '/invite', to: 'invite#new'
+  post '/invite', to: 'invite#create'
 
   namespace :admin do
     get "/dashboard", to: "dashboard#show"

--- a/spec/features/user/user_can_invite_github_user_spec.rb
+++ b/spec/features/user/user_can_invite_github_user_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe 'A registered user' do
+  before :each do
+    @user = create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+  end
+  it 'can invite someone from github to the app' do
+    @user.update(github_token: ENV["GITHUB_TOKEN_A"], github_username: ENV["GITHUB_USERNAME_A"])
+
+    visit dashboard_path
+    click_button "Send an Invite"
+
+    expect(current_path).to eq(invite_path)
+
+    fill_in :github_username, with: ENV["GITHUB_USERNAME_B"]
+    click_button "Send Invite"
+
+    expect(current_path).to eq(dashboard_path)
+    expect(page).to have_content("Successfully sent invite!")
+
+    invitation_email = ActionMailer::Base.deliveries.last
+
+    expect(invitation_email.text_part.body).to have_content("Hello #{ENV["GITHUB_USERNAME_B"]}")
+    expect(invitation_email.text_part.body).to have_content("#{ENV["GITHUB_USERNAME_A"]} has invited you to join Secure Fjord. You can create an account here")
+
+  end
+
+  it "has a sad path if github user doesn't make email available" do
+    @user.update(github_token: ENV["GITHUB_TOKEN_B"], github_username: ENV["GITHUB_USERNAME_B"])
+
+    visit dashboard_path
+    click_button "Send an Invite"
+
+    expect(current_path).to eq(invite_path)
+
+    fill_in :github_username, with: ENV["GITHUB_USERNAME_A"]
+    click_button "Send Invite"
+
+    expect(current_path).to eq(dashboard_path)
+    expect(page).to have_content("The Github user you selected doesn't have an email address associated with their account.")
+  end
+
+  it "has a sad path if an invalid github username is invited" do
+    @user.update(github_token: ENV["GITHUB_TOKEN_B"], github_username: ENV["GITHUB_USERNAME_B"])
+
+    visit dashboard_path
+    click_button "Send an Invite"
+
+    expect(current_path).to eq(invite_path)
+
+    fill_in :github_username, with: "Imprettysurethisisntavalidgithubname"
+    click_button "Send Invite"
+
+    expect(current_path).to eq(invite_path)
+    expect(page).to have_content("There is no Github user with that username.")
+  end
+end

--- a/spec/mailers/invitation_spec.rb
+++ b/spec/mailers/invitation_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe InvitationMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/invitation_preview.rb
+++ b/spec/mailers/previews/invitation_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/invitation
+class InvitationPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
Can send an invitation email to a github user through the app. Has sad paths for both a github user that hasn't made their email public and an invalid github username.